### PR TITLE
Update KafkaSource isolation level for Kafka EOS cookbook to read_committed

### DIFF
--- a/kafka-exactly-once/src/main/java/com/immerok/cookbook/KafkaExactlyOnce.java
+++ b/kafka-exactly-once/src/main/java/com/immerok/cookbook/KafkaExactlyOnce.java
@@ -1,5 +1,6 @@
 package com.immerok.cookbook;
 
+import java.util.Locale;
 import java.util.Properties;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
@@ -11,11 +12,13 @@ import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.IsolationLevel;
 
 public class KafkaExactlyOnce {
 
-    static final String TOPIC = "input";
+    static final String INPUT = "input";
     static final String OUTPUT = "output";
 
     public static void main(String[] args) throws Exception {
@@ -23,13 +26,19 @@ public class KafkaExactlyOnce {
     }
 
     static void runJob() throws Exception {
+        var consumerProperties = new Properties();
+        consumerProperties.setProperty(
+                ConsumerConfig.ISOLATION_LEVEL_CONFIG,
+                IsolationLevel.READ_COMMITTED.toString().toLowerCase(Locale.ROOT));
+
         KafkaSource<String> source =
                 KafkaSource.<String>builder()
                         .setBootstrapServers("localhost:9092")
-                        .setTopics(TOPIC)
+                        .setTopics(INPUT)
                         .setGroupId("KafkaExactlyOnceRecipeApplication")
                         .setStartingOffsets(
                                 OffsetsInitializer.committedOffsets(OffsetResetStrategy.EARLIEST))
+                        .setProperties(consumerProperties)
                         .setValueOnlyDeserializer(new SimpleStringSchema())
                         .build();
 

--- a/kafka-exactly-once/src/test/java/com/immerok/cookbook/KafkaExactlyOnceTest.java
+++ b/kafka-exactly-once/src/test/java/com/immerok/cookbook/KafkaExactlyOnceTest.java
@@ -1,22 +1,31 @@
 package com.immerok.cookbook;
 
+import static com.immerok.cookbook.KafkaExactlyOnce.INPUT;
 import static com.immerok.cookbook.KafkaExactlyOnce.OUTPUT;
-import static com.immerok.cookbook.KafkaExactlyOnce.TOPIC;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.immerok.cookbook.events.StringSuppplier;
 import com.immerok.cookbook.extensions.FlinkMiniClusterExtension;
 import com.immerok.cookbook.utils.CookbookKafkaCluster;
-import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
 import java.util.stream.Stream;
+import net.mguenther.kafka.junit.ObserveKeyValues;
 import net.mguenther.kafka.junit.TopicConfig;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.IsolationLevel;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(FlinkMiniClusterExtension.class)
 class KafkaExactlyOnceTest {
@@ -30,36 +39,69 @@ class KafkaExactlyOnceTest {
     @Disabled("Not running 'testProductionJob()' because it is a manual test.")
     void testProductionJob() throws Exception {
         try (final CookbookKafkaCluster kafka = new CookbookKafkaCluster()) {
-            kafka.createTopicAsync(TOPIC, Stream.generate(new StringSuppplier()));
+            kafka.createTopicAsync(INPUT, Stream.generate(new StringSuppplier()), false);
             kafka.createTopic(TopicConfig.withName(OUTPUT));
 
             KafkaExactlyOnce.runJob();
         }
     }
 
-    @Test
-    void JobProducesExpectedNumberOfResults() throws Exception {
-        final int numExpectedRecords = 50;
+    @ParameterizedTest
+    @MethodSource("exactlyOnceScenarios")
+    void JobProducesExpectedNumberOfResults(
+            String isolationLevel,
+            int numRecordsToSend,
+            boolean failTransactions,
+            int numExpectedRecords)
+            throws Exception {
         try (final CookbookKafkaCluster kafka = new CookbookKafkaCluster()) {
             kafka.createTopic(
-                    TOPIC, Stream.generate(new StringSuppplier()).limit(numExpectedRecords));
+                    INPUT,
+                    Stream.generate(new StringSuppplier()).limit(numRecordsToSend),
+                    failTransactions);
+            kafka.observe(
+                    ObserveKeyValues.on(INPUT, numRecordsToSend)
+                            .with(
+                                    ConsumerConfig.ISOLATION_LEVEL_CONFIG,
+                                    IsolationLevel.READ_UNCOMMITTED
+                                            .toString()
+                                            .toLowerCase(Locale.ROOT)));
+
+            var consumerProperties = new Properties();
+            consumerProperties.setProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolationLevel);
 
             KafkaSource<String> source =
                     KafkaSource.<String>builder()
                             .setBootstrapServers("localhost:9092")
-                            .setTopics(TOPIC)
+                            .setTopics(INPUT)
                             .setStartingOffsets(OffsetsInitializer.earliest())
-                            // set an upper bound so that the job (and this test) will end
-                            .setBounded(OffsetsInitializer.latest())
+                            .setProperties(consumerProperties)
                             .setValueOnlyDeserializer(new SimpleStringSchema())
                             .build();
 
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
             KafkaExactlyOnce.defineWorkflow(env, source);
-            env.execute();
+            JobClient jobClient = env.executeAsync();
 
-            final List<String> topicRecords = kafka.getTopicRecords(TOPIC, numExpectedRecords + 1);
-            assertThat(topicRecords).hasSize(numExpectedRecords);
+            kafka.observe(ObserveKeyValues.on(OUTPUT, numExpectedRecords));
+            assertThat(jobClient.cancel().cancel(true)).isTrue();
         }
+    }
+
+    static Stream<Arguments> exactlyOnceScenarios() {
+        return Stream.of(
+                /**
+                 * When the transactions are successful, all the records are read, regardless of the
+                 * isolation level.
+                 */
+                arguments("read_committed", 50, false, 50),
+                arguments("read_uncommitted", 50, false, 50),
+                /**
+                 * When the transactions fail, Flink KafkaSource considers aborted data when the
+                 * isolation level is read_uncommitted (ideal for E2E ALO), but ignores it when the
+                 * isolation_level is read_committed (ideal for E2E EOS)
+                 */
+                arguments("read_uncommitted", 50, true, 50),
+                arguments("read_committed", 50, true, 0));
     }
 }


### PR DESCRIPTION
Hi, Immerok team! 👋 

I became aware of your exciting project in the last few days and eventually learned about these recipes.

I faced an interesting challenge not a while ago where duplicate records arrived at non-idempotent sinks while using a similar code structure to the one provided in the [kafka-exactly-once](https://github.com/immerok/recipes/tree/main/kafka-exactly-once) recipe. At the end of the day, one realized that this was due to using the default isolation level for the Flink `KafkaSource`, which is `read_uncommitted`. 

As such, I hereby submit a small contribution for your appreciation that prevents the `KafkaSource` from reading records aborted within a transaction by idempotent Kafka producers, along with tests that evidence such occurrences.

Let me know if it makes sense to you. I believe this is of utmost importance for strict E2E EOS scenarios and may prevent quality issues from happening.

Keen to see your future work, and thanks for sharing this with the community! 🚀 